### PR TITLE
release: v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 2.1.0
+
+### 🚀 New Features
+
+- **Barrier gesture penetration** — `DrawerConfig.barrierPenetrable` lets pointer events pass through the backdrop to widgets behind the drawer ([#6](https://github.com/oi-narendra/anydrawer/issues/6)).
+
+### 🔧 Maintenance
+
+- Narrowed Dart SDK upper bound from `<5.0.0` to `<4.0.0`.
+- Updated `very_good_analysis` to 10.3.0 and refreshed lockfile dependencies.
+
 ## 2.0.0
 
 ### ⚠️ Breaking Changes

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Flutter's built-in `Drawer` widget is tied to `Scaffold`, limited to left/right,
 | Width constraints (min/max)    | ❌                 | ✅                |
 | Custom animation curve         | ❌                 | ✅                |
 | Works with dialogs on top      | ❌                 | ✅                |
+| Barrier tap-through            | ❌                 | ✅                |
 | Accessibility (semantics)      | Partial            | ✅                |
 
 ---
@@ -69,6 +70,7 @@ Flutter's built-in `Drawer` widget is tied to `Scaffold`, limited to left/right,
 - 👆 **Swipe-from-edge** — `AnyDrawerRegion` detects edge swipes to open
 - ✨ **Elevation & shadow** — Material shadow on the drawer edge
 - 🎨 **Custom barrier** — provide your own barrier widget
+- 👆 **Barrier tap-through** — `barrierPenetrable` lets taps reach widgets behind the drawer
 - ⌨️ **Close on Escape / Back** — keyboard and Android back button
 - 📐 **Width constraints** — `maxWidth` and `minWidth` for responsive layouts
 - ♿ **Accessibility** — built-in semantics label support
@@ -99,7 +101,7 @@ Flutter's built-in `Drawer` widget is tied to `Scaffold`, limited to left/right,
 
 ```yaml
 dependencies:
-  anydrawer: ^2.0.0
+  anydrawer: ^2.1.0
 ```
 
 ```bash

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1088,7 +1088,7 @@ class _DialogDemoDrawerContent extends StatelessWidget {
               showAboutDialog(
                 context: context,
                 applicationName: 'AnyDrawer',
-                applicationVersion: '2.0.0',
+                applicationVersion: '2.1.0',
                 children: [
                   const Text('Dialogs work seamlessly inside drawers.'),
                 ],

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,9 +1,8 @@
 name: anydrawer
 description: >-
-  A powerful Flutter drawer that slides from any edge — left, right, top, or bottom.
-  No Scaffold required. Supports backdrop blur, drag gestures, return values,
-  multiple drawers, swipe-from-edge, and declarative API.
-version: 2.0.0
+  A Flutter drawer that slides from any edge. No Scaffold needed — backdrop blur,
+  drag, return values, swipe-from-edge, multiple drawers, and declarative API.
+version: 2.1.0
 homepage: https://github.com/oi-narendra/anydrawer
 topics:
   - drawer


### PR DESCRIPTION
## Summary
- Bump version to **2.1.0** (minor release)
- Add changelog entry for `barrierPenetrable` gesture penetration ([#6](https://github.com/oi-narendra/anydrawer/issues/6)) and maintenance updates
- Shorten `pubspec.yaml` description to 156 characters (pub.dev recommends 60–180 for search snippets)
- Update README with barrier tap-through in feature list/comparison table and install constraint `^2.1.0`

## Test plan
- [ ] Verify pub.dev description length check passes on publish
- [ ] Confirm README renders correctly on GitHub
- [ ] Run `flutter test` in package root
- [ ] Tag and publish after merge


Made with [Cursor](https://cursor.com)