### PR TITLE
fix(ci): repair publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,19 +7,16 @@ on:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+*" # tag-pattern on pub.dev: 'v'
 
-env:
-  PUB_HOSTED_URL: https://pub.dartlang.org
-  PUB_CACHE: /github/workspace/.pub-cache
-
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup Flutter
-        uses: subosito/flutter-action@v1
+        uses: subosito/flutter-action@v2
         with:
-          flutter-version: "3.13.0"
+          channel: stable
+          cache: true
       - name: Install dependencies
         run: flutter pub get
       - name: Run tests
@@ -27,23 +24,24 @@ jobs:
 
   publish:
     needs: test
+    if: startsWith(github.ref, 'refs/tags/v')
     permissions:
       id-token: write # Required for authentication using OIDC
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup Flutter
-        uses: subosito/flutter-action@v1
+        uses: subosito/flutter-action@v2
         with:
-          flutter-version: "3.13.0"
+          channel: stable
+          cache: true
       - name: Install dependencies
         run: flutter pub get
-      - name: Create flutter publishing token flutter
+      - name: Authenticate with pub.dev
         run: |
           set -eo pipefail
           PUB_TOKEN=$(curl --retry 5 --retry-connrefused -sLS "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=https://pub.dev" -H "User-Agent: actions/oidc-client" -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" | jq -r '.value')
           echo "PUB_TOKEN=${PUB_TOKEN}" >> $GITHUB_ENV
-          export PUB_TOKEN
           flutter pub token add https://pub.dev --env-var PUB_TOKEN
       - name: Publish to pub.dev
         run: flutter pub publish --force


### PR DESCRIPTION
## Summary
- Remove broken `PUB_CACHE: /github/workspace/.pub-cache` (permission denied on runners)
- Upgrade `actions/checkout@v4` and `subosito/flutter-action@v2` (Node 20 deprecation)
- Use Flutter `stable` channel instead of pinned 3.13.0
- Publish only on version tags, not every `main` push

## Test plan
- [ ] CI test job passes on this PR
- [ ] Re-tag `v2.1.0` after merge to trigger pub.dev publish


Made with [Cursor](https://cursor.com)